### PR TITLE
Restore the landing help box and part of the copy

### DIFF
--- a/src/app/landing/landing.tpl.html
+++ b/src/app/landing/landing.tpl.html
@@ -1,5 +1,13 @@
 <div>
   <div class="main container landing">
+    <div class="helpbox" ng-class="{showHelp : showHelp}">
+      <h3>Welcome to Stellar Charts</h3>
+      <p>
+        This charting site provides live and historical data about the Stellar network.
+        This site is open for anyone to use, alter and embed. The source code is available
+        <a href="https://github.com/stellar/stellar-charts-frontend" target="_blank">here</a>.
+      </p>
+    </div>
     <div class="row">
       <div class="col-md-6 stats">
         <h5>


### PR DESCRIPTION
#7 removed the help text box for the landing page, breaking the help (?) button.
Only the first sentence of the copy needed to be removed.